### PR TITLE
Replacing mpsc

### DIFF
--- a/src/miner.rs
+++ b/src/miner.rs
@@ -38,9 +38,7 @@ impl MinerManager {
         let hashes_tried = Arc::new(AtomicU64::new(0));
         let (send, recv) = watch::channel(None);
         let handels = (0..num_threads)
-            .map(|_| {
-                Self::launch_miner(send_channel.clone(), recv.clone(), Arc::clone(&hashes_tried))
-            })
+            .map(|_| Self::launch_miner(send_channel.clone(), recv.clone(), Arc::clone(&hashes_tried)))
             .collect();
         Self {
             handles: handels,

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -41,7 +41,14 @@ impl State {
         hasher.update(pre_pow_hash).update(header.timestamp.to_le_bytes()).update([0u8; 32]);
         let matrix = Arc::new(Matrix::generate(pre_pow_hash));
 
-        Ok(Self { id: STATE_ID.fetch_add(1, Ordering::SeqCst), matrix, nonce: 0, target, block: Arc::new(block), hasher })
+        Ok(Self {
+            id: STATE_ID.fetch_add(1, Ordering::SeqCst),
+            matrix,
+            nonce: 0,
+            target,
+            block: Arc::new(block),
+            hasher,
+        })
     }
 
     #[inline(always)]


### PR DESCRIPTION
Using `mpsc` to send blocks to threads might cause a backlog if threads are slow to poll the channel. As a result, threads might try to solve outdated blocks, and in the extreme case, the channel will fill up, and this affected the RPC behavior

This mostly affected GPU threads, where polling was slower