### PR TITLE
Handroll a single producer multi receiver implementation (watch channel)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,6 @@
 name: Tests
 
-on:
-  push:
-  pull_request:
-    # edtited - because base branch can be modified
-    # synchronize - update commits on PR
-    types: [opened, synchronize, edited]
+on: [push, pull_request]
 
 jobs:
 
@@ -38,6 +33,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --tests
+
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
@@ -71,11 +68,88 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run cargo test
+      - name: Run cargo test regular features
         uses: actions-rs/cargo@v1
         with:
           command: test
 
+      - name: Run cargo test no asm
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features=no-asm
+
+
+      - name: Run cargo test no parking_lot
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
+      - name: Run cargo test shuttle
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=shuttle
+
+
+
+  test-release:
+    name: Test Suite Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Fix CRLF on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.autocrlf false
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run cargo test release regular features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release
+
+      - name: Run cargo test release no asm
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features=no-asm --release
+
+      - name: Run cargo test release no parking_lot
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --release
+
+      - name: Run cargo test release shuttle
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features=shuttle --release
 
   lints:
     name: Lints
@@ -114,4 +188,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --tests -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470fbd40e959c961f16841fbf96edbbdcff766ead89a1ae2b53d22852be20998"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "funty"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +276,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d9279ca822891c1a4dae06d185612cf8fc6acfe5dff37781b41297811b12ee"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,13 +300,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -320,6 +362,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -445,8 +493,9 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prost",
- "rand",
+ "rand 0.8.4",
  "sha3",
+ "shuttle",
  "structopt",
  "tokio",
  "tokio-stream",
@@ -730,15 +779,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -748,7 +826,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -757,7 +844,16 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.3",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -766,7 +862,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -805,6 +910,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +939,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "shuttle"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6488127237c77b868dea6f506a64dd0e41dbc0e37ad69a7d392374702f6759"
+dependencies = [
+ "ansi_term",
+ "bitvec",
+ "generator",
+ "hex",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "rand_pcg",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+ "varmint",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,9 +965,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -885,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,7 +1034,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1034,7 +1176,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.4",
  "slab",
  "tokio",
  "tokio-stream",
@@ -1130,6 +1272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "varmint"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37964b04ce5402f3c72374add45209115a44782d83a1ddfd4ca372d12ddd45d7"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1298,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1198,3 +1352,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +443,7 @@ dependencies = [
  "log",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "prost",
  "rand",
  "sha3",
@@ -461,6 +471,15 @@ name = "libc"
 version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -535,6 +554,31 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -761,6 +805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "git+https://github.com/elichai/hashes?branch=cSHAKE#c3847d04c37f4d486db591ce1bc43c9e41a39e36"
@@ -776,6 +826,12 @@ name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"
@@ -872,6 +928,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "tokio-macros",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["blockchain", "cli"]
 
 [dependencies]
 tonic = "0.6"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "parking_lot"] }
 prost = "0.9"
 futures-util = "0.3"
 tokio-stream = "0.1"
@@ -23,6 +23,7 @@ structopt = { version = "0.3", features = ["color" ]}
 log = "0.4"
 env_logger = "0.9"
 keccak = {version = "0.1", optional = true }
+parking_lot = "0.11"
 
 [features]
 bench = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ default = ["parking_lot"]
 bench = []
 no-asm = ["keccak"]
 
+[target.'cfg(target_os = "windows")'.dependencies]
+keccak = "0.1"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ structopt = { version = "0.3", features = ["color" ]}
 log = "0.4"
 env_logger = "0.9"
 keccak = {version = "0.1", optional = true }
-parking_lot = "0.11"
+parking_lot = {version = "0.11", optional = true}
+shuttle = { version = "0.0.7", optional = true }
 
 [features]
+default = ["parking_lot"]
 bench = []
 no-asm = ["keccak"]
 
@@ -39,3 +41,4 @@ cc = "1"
 
 [dev-dependencies]
 sha3 = { git = "https://github.com/elichai/hashes", branch = "cSHAKE" }
+shuttle = {version = "0.0.7"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod kaspad_messages;
 mod miner;
 mod pow;
 mod target;
+mod watch;
 
 pub mod proto {
     tonic::include_proto!("protowire");

--- a/src/pow/keccak.rs
+++ b/src/pow/keccak.rs
@@ -1,9 +1,9 @@
-#[cfg(any(not(target_arch = "x86_64"), feature = "no-asm"))]
+#[cfg(any(not(target_arch = "x86_64"), feature = "no-asm", target_os = "windows"))]
 pub(super) fn f1600(state: &mut [u64; 25]) {
     keccak::f1600(state);
 }
 
-#[cfg(all(target_arch = "x86_64", not(feature = "no-asm")))]
+#[cfg(all(target_arch = "x86_64", not(feature = "no-asm"), not(target_os = "windows")))]
 pub(super) fn f1600(state: &mut [u64; 25]) {
     extern "C" {
         fn KeccakF1600(state: &mut [u64; 25]);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,156 @@
+use parking_lot::{Condvar, Mutex, RwLock};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+// The value is in a RWLock, all receivers observe it using a read lock + clone
+// id is used to check if there's a new value before reading the old value.
+// readers count is so that receivers and senders can know if everyone dropped their channels
+// wait_for_change + notify_change is to allow receivers to wait for new values.
+
+struct Shared<T: Clone> {
+    value: RwLock<T>,
+    id: AtomicUsize,
+    wait_for_change: Mutex<()>,
+    notify_change: Condvar,
+    receivers_count: AtomicUsize,
+    sender_alive: AtomicBool,
+}
+
+impl<T: Clone> Shared<T> {
+    fn receiver_count(&self) -> usize {
+        self.receivers_count.load(Ordering::Acquire)
+    }
+
+    fn increment_receiver_count(&self) {
+        self.receivers_count.fetch_add(1, Ordering::Release);
+    }
+
+    fn decrement_receivers_count(&self) {
+        self.receivers_count.fetch_sub(1, Ordering::Release);
+    }
+
+    fn drop_sender(&self) {
+        self.sender_alive.store(false, Ordering::Release);
+    }
+
+    fn sender_alive(&self) -> bool {
+        self.sender_alive.load(Ordering::Acquire)
+    }
+
+    fn replace_value(&self, val: T) {
+        *self.value.write() = val;
+    }
+
+    fn increment_id(&self) -> usize {
+        self.id.fetch_add(1, Ordering::Release)
+    }
+
+    fn id(&self) -> usize {
+        self.id.load(Ordering::Acquire)
+    }
+
+    fn clone_value(&self) -> T {
+        self.value.read().clone()
+    }
+}
+
+pub fn channel<T: Clone>(init: T) -> (Sender<T>, Receiver<T>) {
+    let shared = Arc::new(Shared {
+        value: RwLock::new(init),
+        id: AtomicUsize::new(0),
+        receivers_count: AtomicUsize::new(1),
+        wait_for_change: Mutex::new(()),
+        notify_change: Condvar::new(),
+        sender_alive: AtomicBool::new(true),
+    });
+    let sender = Sender { shared: Arc::clone(&shared) };
+    let receiver = Receiver { shared: Arc::clone(&shared), last_observed: 0 };
+    (sender, receiver)
+}
+
+pub struct Sender<T: Clone> {
+    shared: Arc<Shared<T>>,
+}
+
+impl<T: Clone> Sender<T> {
+    pub fn send(&self, value: T) -> Result<(), ChannelClosed> {
+        // if no receiver left, return an error
+        if self.shared.receiver_count() == 0 {
+            return Err(ChannelClosed(()));
+        }
+        self.shared.replace_value(value);
+        // Signal that the value has been changed.
+        self.shared.increment_id();
+        // Notify in-case any receiver is waiting
+        self.shared.notify_change.notify_all();
+        Ok(())
+    }
+}
+
+impl<T: Clone> Drop for Sender<T> {
+    fn drop(&mut self) {
+        // Mark sender as dropped
+        self.shared.drop_sender();
+        // Make sure all waiting receivers will unlock and see that the sender was dropped.
+        self.shared.notify_change.notify_all();
+    }
+}
+
+pub struct Receiver<T: Clone> {
+    shared: Arc<Shared<T>>,
+    last_observed: usize,
+}
+
+impl<T: Clone> Receiver<T> {
+    pub fn get_changed(&mut self) -> Result<Option<T>, ChannelClosed> {
+        if !self.shared.sender_alive() {
+            return Err(ChannelClosed(()));
+        }
+        let new_id = self.shared.id();
+        if self.last_observed == new_id {
+            return Ok(None);
+        }
+        self.last_observed = new_id;
+        Ok(Some(self.shared.clone_value()))
+    }
+
+    pub fn wait_for_change(&mut self) -> Result<T, ChannelClosed> {
+        if let Some(v) = self.get_changed()? {
+            return Ok(v);
+        }
+        // wait for a notification of a new value
+        self.shared.notify_change.wait(&mut self.shared.wait_for_change.lock());
+        // Recheck if the sender is alive as it might've changed while waiting
+        if !self.shared.sender_alive() {
+            return Err(ChannelClosed(()));
+        }
+        self.last_observed = self.shared.id();
+        Ok(self.shared.clone_value())
+    }
+}
+
+impl<T: Clone> Clone for Receiver<T> {
+    fn clone(&self) -> Self {
+        self.shared.increment_receiver_count();
+        Self { shared: Arc::clone(&self.shared), last_observed: self.last_observed }
+    }
+}
+
+impl<T: Clone> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        self.shared.decrement_receivers_count();
+    }
+}
+
+#[derive(Debug)]
+pub struct ChannelClosed(());
+
+impl Display for ChannelClosed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Channel is closed")
+    }
+}
+
+impl Error for ChannelClosed {}


### PR DESCRIPTION
The watch channel is kept inside regular CPU threads, not async tasks. so because of that using a `tokio::watch` channel required keeping a runtime for each CPU worker, which kinda sucks.
also the `block_on` implementation had a lot of overhead.

This implementation assumes `T: Clone` (which is true for our case), and allows you to block on new states using non-async regular sync primitives.