### PR TITLE
New CLI-Parameter: --throttle-microseconds for better cpu control

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,7 +39,7 @@ pub struct Opt {
     /// Mine even when kaspad says it is not synced, only useful when passing `--allow-submit-block-when-not-synced` to kaspad  [default: false]
     pub mine_when_not_synced: bool,
     #[clap(long = "throttle", display_order = 9)]
-    /// Throttle (milliseconds) between each pow hash generation (used for development testing)
+    /// Throttle (microseconds) between each pow hash generation (used for development testing)
     pub throttle: Option<u64>,
     #[clap(long, display_order = 10)]
     /// Output logs in alternative format (same as kaspad)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use std::{net::IpAddr, str::FromStr};
 
 #[derive(Debug, Parser)]
 #[clap(about, version, author)]
+#[clap(group(ArgGroup::new("throttle_group").args(&["throttle", "throttle_microseconds"])))]
 #[clap(group(ArgGroup::new("required")))]
 pub struct Opt {
     #[clap(short, long, display_order = 3)]
@@ -39,9 +40,12 @@ pub struct Opt {
     /// Mine even when kaspad says it is not synced, only useful when passing `--allow-submit-block-when-not-synced` to kaspad  [default: false]
     pub mine_when_not_synced: bool,
     #[clap(long = "throttle", display_order = 9)]
-    /// Throttle (microseconds) between each pow hash generation (used for development testing)
+    /// Throttle (milliseconds) between each pow hash generation (used for development testing)
     pub throttle: Option<u64>,
-    #[clap(long, display_order = 10)]
+    #[clap(long = "throttle-microseconds", display_order = 10)]
+    /// Throttle (microseconds) between each pow hash generation (used for development testing)
+    pub throttle_microseconds: Option<u64>,
+    #[clap(long, display_order = 11)]
     /// Output logs in alternative format (same as kaspad)
     pub altlogs: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Error> {
     }
     builder.init();
 
-    let throttle = opt.throttle.map(Duration::from_millis);
+    let throttle = opt.throttle.map(Duration::from_micros);
     let shutdown = ShutdownHandler(Arc::new(AtomicBool::new(false)));
     let _shutdown_when_dropped = shutdown.arm();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Error> {
     }
     builder.init();
 
-    let throttle = opt.throttle.map(Duration::from_micros);
+    let throttle = opt.throttle.map(Duration::from_millis).or_else(|| opt.throttle_microseconds.map(Duration::from_micros));
     let shutdown = ShutdownHandler(Arc::new(AtomicBool::new(false)));
     let _shutdown_when_dropped = shutdown.arm();
 


### PR DESCRIPTION
For Testing purposes  (tn10, tn11):

New cli-parameter --throttle-microseconds for better control of cpu usage.

Example: Running `kaspa-miner -t 100 --throttle 40 ` creates 1 Mhash/s on a system with ryzen 5950X, but the cpu temperature drops from 75deg celsius to 65deg celsius. Just play around with -t (threads) and --throttle-microseconds. With --throttle 1(ms) you cannot achieve 1 Mhash/s.

Linux: no problem with microsecond sleep
Windows: Windows 10, Version 1803 should support microsecond sleep
[Windows: Support sub-millisecond sleep #116461](https://github.com/rust-lang/rust/pull/116461)
[// Attempt to use high-precision sleep (Windows 10, version 1803+).](https://github.com/rust-lang/rust/blob/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/std/src/sys/pal/windows/thread.rs#L100C8-L100C9)
